### PR TITLE
add valSwap checker

### DIFF
--- a/testdata/valSwap/negative_tests.go
+++ b/testdata/valSwap/negative_tests.go
@@ -1,0 +1,17 @@
+package checker_test
+
+func fieldSwapOK(p *pair) {
+	p.first, p.second = p.second, p.first
+}
+
+func varSwapOK(x, y int) {
+	x, y = y, x
+}
+
+func pointersSwap1OK(x, y *int) {
+	*x, *y = *y, *x
+}
+
+func pointersSwap2OK(x, y *int) {
+	*y, *x = *x, *y
+}

--- a/testdata/valSwap/negative_tests.go
+++ b/testdata/valSwap/negative_tests.go
@@ -15,3 +15,9 @@ func pointersSwap1OK(x, y *int) {
 func pointersSwap2OK(x, y *int) {
 	*y, *x = *x, *y
 }
+
+func notSwap(x, y int) {
+	tmp := x
+	y = x // logic error here, probably...
+	y = tmp
+}

--- a/testdata/valSwap/positive_tests.go
+++ b/testdata/valSwap/positive_tests.go
@@ -1,0 +1,34 @@
+package checker_test
+
+type pair struct {
+	first  int
+	second int
+}
+
+func fieldSwap(p *pair) {
+	/*! can re-write as `p.first, p.second = p.second, p.first` */
+	tmp := p.first
+	p.first = p.second
+	p.second = tmp
+}
+
+func varSwap(x, y int) {
+	/*! can re-write as `x, y = y, x` */
+	tmp := x
+	x = y
+	y = tmp
+}
+
+func pointersSwap1(x, y *int) {
+	/*! can re-write as `*x, *y = *y, *x` */
+	tmp := *x
+	*x = *y
+	*y = tmp
+}
+
+func pointersSwap2(x, y *int) {
+	/*! can re-write as `*y, *x = *x, *y` */
+	tmp := *y
+	*y = *x
+	*x = tmp
+}

--- a/valSwap_checker.go
+++ b/valSwap_checker.go
@@ -1,0 +1,64 @@
+package checkers
+
+import (
+	"go/ast"
+	"go/token"
+
+	"github.com/go-lintpack/lintpack"
+	"github.com/go-lintpack/lintpack/astwalk"
+	"github.com/go-toolsmith/astcast"
+	"github.com/go-toolsmith/astequal"
+)
+
+func init() {
+	var info lintpack.CheckerInfo
+	info.Name = "valSwap"
+	info.Tags = []string{"style", "experimental"}
+	info.Summary = "Detects value swapping code that are not using parallel assignment"
+	info.Before = `
+tmp := *x
+*x = *y
+*y = tmp`
+	info.After = `*x, *y = *y, *x`
+
+	collection.AddChecker(&info, func(ctx *lintpack.CheckerContext) lintpack.FileWalker {
+		return astwalk.WalkerForStmtList(&valSwapChecker{ctx: ctx})
+	})
+}
+
+type valSwapChecker struct {
+	astwalk.WalkHandler
+	ctx *lintpack.CheckerContext
+}
+
+func (c *valSwapChecker) VisitStmtList(list []ast.Stmt) {
+	for len(list) >= 3 {
+		tmpAssign := astcast.ToAssignStmt(list[0])
+		assignX := astcast.ToAssignStmt(list[1])
+		assignY := astcast.ToAssignStmt(list[2])
+
+		cond := c.isSimpleAssign(tmpAssign) &&
+			c.isSimpleAssign(assignX) &&
+			c.isSimpleAssign(assignY) &&
+			assignX.Tok == token.ASSIGN &&
+			assignY.Tok == token.ASSIGN &&
+			astequal.Expr(assignX.Lhs[0], tmpAssign.Rhs[0]) &&
+			astequal.Expr(assignX.Rhs[0], assignY.Lhs[0]) &&
+			astequal.Expr(assignY.Rhs[0], tmpAssign.Lhs[0])
+		if cond {
+			c.warn(tmpAssign, assignX.Lhs[0], assignY.Lhs[0])
+			list = list[3:]
+		} else {
+			list = list[1:]
+		}
+	}
+}
+
+func (c *valSwapChecker) isSimpleAssign(x *ast.AssignStmt) bool {
+	return len(x.Lhs) == 1 && len(x.Rhs) == 1
+}
+
+func (c *valSwapChecker) warn(cause, x, y ast.Node) {
+	c.ctx.Warn(cause, "can re-write as `%s, %s = %s, %s`",
+		x, y, y, x)
+}


### PR DESCRIPTION
Finds
	`$tmp := $x; $x = $y; $y = $tmp`
and suggests to replace them with
	`$x, $y = $y, $x`

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>