### PR TITLE
make deprecatedComment warning location more precise

### DIFF
--- a/deprecatedComment_checker.go
+++ b/deprecatedComment_checker.go
@@ -84,28 +84,34 @@ func (c *deprecatedCommentChecker) VisitDocComment(doc *ast.CommentGroup) {
 	//
 	// TODO(quasilyte): there are also multi-line deprecation comments.
 
-	for _, l := range strings.Split(doc.Text(), "\n") {
+	for _, comment := range doc.List {
+		if strings.HasPrefix(comment.Text, "/*") {
+			// TODO(quasilyte): handle multi-line doc comments.
+			continue
+		}
+		l := comment.Text[len("//"):]
 		if len(l) < len("Deprecated: ") {
 			continue
 		}
+		l = strings.TrimSpace(l)
 
 		// Check whether someone messed up with a prefix casing.
 		upcase := strings.ToUpper(l)
 		if strings.HasPrefix(upcase, "DEPRECATED: ") && !strings.HasPrefix(l, "Deprecated: ") {
-			c.warnCasing(doc, l)
+			c.warnCasing(comment, l)
 			return
 		}
 
 		// Check is someone used comma instead of a colon.
 		if strings.HasPrefix(l, "Deprecated, ") {
-			c.warnComma(doc)
+			c.warnComma(comment)
 			return
 		}
 
 		// Check for other commonly used patterns.
 		for _, pat := range c.commonPatterns {
 			if pat.MatchString(l) {
-				c.warnPattern(doc)
+				c.warnPattern(comment)
 				return
 			}
 		}
@@ -113,7 +119,7 @@ func (c *deprecatedCommentChecker) VisitDocComment(doc *ast.CommentGroup) {
 		// Detect some simple typos.
 		for _, prefixWithTypo := range c.commonTypos {
 			if strings.HasPrefix(upcase, prefixWithTypo) {
-				c.warnTypo(doc, l)
+				c.warnTypo(comment, l)
 				return
 			}
 		}

--- a/testdata/_integration/check_main_only/linttest.golden
+++ b/testdata/_integration/check_main_only/linttest.golden
@@ -8,7 +8,7 @@ exit status 1
 ./main.go:37:2: caseOrder: case int must go before the interface{} case
 ./main.go:42:2: commentedOutCode: may want to remove commented-out code
 ./main.go:49:2: defaultCaseOrder: consider to make `default` case as first or as last case
-./main.go:56:1: deprecatedComment: the proper format is `Deprecated: <text>`
+./main.go:58:1: deprecatedComment: the proper format is `Deprecated: <text>`
 ./main.go:62:1: docStub: silencing go lint doc-comment warnings is unadvised
 ./main.go:65:2: dupArg: suspicious duplicated args in `copy(xs, xs)`
 ./main.go:69:2: dupBranchBody: both branches in if statement has same body


### PR DESCRIPTION
Tests already expect that warnings point to the correct
line, now submit the implementation. The integration
tests lost sync for some time, fix that as well.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>