### PR TITLE
add commentedOutImport checker

### DIFF
--- a/commentedOutImport_checker.go
+++ b/commentedOutImport_checker.go
@@ -1,0 +1,75 @@
+package checkers
+
+import (
+	"go/ast"
+	"go/token"
+	"regexp"
+
+	"github.com/go-lintpack/lintpack"
+	"github.com/go-lintpack/lintpack/astwalk"
+)
+
+func init() {
+	var info lintpack.CheckerInfo
+	info.Name = "commentedOutImport"
+	info.Tags = []string{"style", "experimental"}
+	info.Summary = "Detects commented-out imports"
+	info.Before = `
+import (
+	"fmt"
+	//"os"
+)`
+	info.After = `
+import (
+	"fmt"
+)`
+
+	collection.AddChecker(&info, func(ctx *lintpack.CheckerContext) lintpack.FileWalker {
+		return &commentedOutImportChecker{
+			ctx:            ctx,
+			importStringRE: regexp.MustCompile(`(?m)^(?://|/\*)?\s*"([a-zA-Z0-9_/]+)"\s*(?:\*/)?$`),
+		}
+	})
+}
+
+type commentedOutImportChecker struct {
+	astwalk.WalkHandler
+	ctx *lintpack.CheckerContext
+
+	importStringRE *regexp.Regexp
+}
+
+func (c *commentedOutImportChecker) WalkFile(f *ast.File) {
+	// TODO(Quasilyte): handle commented-out import spec,
+	// for example: // import "errors".
+
+	for _, decl := range f.Decls {
+		decl, ok := decl.(*ast.GenDecl)
+		if !ok || decl.Tok != token.IMPORT {
+			// Import decls can only be in the beginning of the file.
+			// If we've met some other decl, there will be no more
+			// import decls.
+			break
+		}
+
+		// Find comments inside this import decl span.
+		for _, cg := range f.Comments {
+			if cg.Pos() > decl.Rparen {
+				break // Below the decl, stop.
+			}
+			if cg.Pos() < decl.Lparen {
+				continue // Before the decl, skip.
+			}
+
+			for _, comment := range cg.List {
+				for _, m := range c.importStringRE.FindAllStringSubmatch(comment.Text, -1) {
+					c.warn(comment, m[1])
+				}
+			}
+		}
+	}
+}
+
+func (c *commentedOutImportChecker) warn(cause ast.Node, path string) {
+	c.ctx.Warn(cause, "remove commented-out %q import", path)
+}

--- a/testdata/_integration/check_comments/foo.go
+++ b/testdata/_integration/check_comments/foo.go
@@ -1,0 +1,19 @@
+package foo
+
+import (
+	"errors"
+	//"os"
+	/*
+		"fmt"
+		"strconv"
+	*/)
+
+import (
+	// "foo/bar"
+	// "foo/bar/baz"
+	_ "errors"
+)
+
+// import "errors"
+
+var _ = errors.New

--- a/testdata/_integration/check_comments/linttest.golden
+++ b/testdata/_integration/check_comments/linttest.golden
@@ -1,0 +1,6 @@
+exit status 1
+./foo.go:5:2: commentedOutImport: remove commented-out "os" import
+./foo.go:6:2: commentedOutImport: remove commented-out "fmt" import
+./foo.go:6:2: commentedOutImport: remove commented-out "strconv" import
+./foo.go:12:2: commentedOutImport: remove commented-out "foo/bar" import
+./foo.go:13:2: commentedOutImport: remove commented-out "foo/bar/baz" import

--- a/testdata/_integration/check_comments/linttest.params
+++ b/testdata/_integration/check_comments/linttest.params
@@ -1,0 +1,1 @@
+check -enable=commentedOutImport -disableTags=none ./... | linttest.golden

--- a/testdata/commentedOutImport/negative_tests.go
+++ b/testdata/commentedOutImport/negative_tests.go
@@ -1,0 +1,18 @@
+package checker_test
+
+import (
+	"fmt"
+)
+
+// Check that it doesn't try to check comments after the imports spec.
+
+var (
+	//"fmt"
+	_ = fmt.Sprint
+)
+
+// "fmt"
+//"fmt"
+
+/*"fmt"*/
+/* "fmt" */

--- a/testdata/commentedOutImport/positive_tests.go
+++ b/testdata/commentedOutImport/positive_tests.go
@@ -1,0 +1,26 @@
+package checker_test
+
+import (
+	"fmt"
+
+	/*! remove commented-out "fmt" import */
+	//"fmt"
+	/*! remove commented-out "fmt" import */
+	// "fmt"
+)
+
+import (
+	/*! remove commented-out "fmt" import */
+	/*"fmt"*/
+	/*! remove commented-out "fmt" import */
+	/* "fmt" */
+
+	/*! remove commented-out "strconv" import */
+	/*! remove commented-out "errors" import */
+	/*
+		"strconv"
+		"errors"
+	*/
+)
+
+var _ = fmt.Sprint


### PR DESCRIPTION
Finds commented-out import specs that are not removed by
goimports of gofmt.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>