### PR TITLE
add offBy1 checker

### DIFF
--- a/offBy1_checker.go
+++ b/offBy1_checker.go
@@ -1,0 +1,66 @@
+package checkers
+
+import (
+	"go/ast"
+	"go/token"
+
+	"github.com/go-lintpack/lintpack"
+	"github.com/go-lintpack/lintpack/astwalk"
+	"github.com/go-toolsmith/astcast"
+	"github.com/go-toolsmith/astcopy"
+	"github.com/go-toolsmith/astequal"
+	"github.com/go-toolsmith/typep"
+)
+
+func init() {
+	var info lintpack.CheckerInfo
+	info.Name = "offBy1"
+	info.Tags = []string{"diagnostic", "experimental"}
+	info.Summary = "Detects various off-by-one kind of errors"
+	info.Before = `xs[len(xs)]`
+	info.After = `xs[len(xs)-1]`
+
+	collection.AddChecker(&info, func(ctx *lintpack.CheckerContext) lintpack.FileWalker {
+		return astwalk.WalkerForExpr(&offBy1Checker{ctx: ctx})
+	})
+}
+
+type offBy1Checker struct {
+	astwalk.WalkHandler
+	ctx *lintpack.CheckerContext
+}
+
+func (c *offBy1Checker) VisitExpr(e ast.Expr) {
+	// TODO(Quasilyte): handle more off-by-1 patterns.
+	// TODO(Quasilyte): check whether go/analysis can help here.
+
+	// Detect s[len(s)] expressions that always panic.
+	// The correct form is s[len(s)-1].
+
+	indexExpr := astcast.ToIndexExpr(e)
+	indexed := indexExpr.X
+	if !typep.IsSlice(c.ctx.TypesInfo.TypeOf(indexed)) {
+		return
+	}
+	if !typep.SideEffectFree(c.ctx.TypesInfo, indexed) {
+		return
+	}
+	call := astcast.ToCallExpr(indexExpr.Index)
+	if astcast.ToIdent(call.Fun).Name != "len" {
+		return
+	}
+	if len(call.Args) != 1 || !astequal.Expr(call.Args[0], indexed) {
+		return
+	}
+	c.warnLenIndex(indexExpr)
+}
+
+func (c *offBy1Checker) warnLenIndex(cause *ast.IndexExpr) {
+	suggest := astcopy.IndexExpr(cause)
+	suggest.Index = &ast.BinaryExpr{
+		Op: token.SUB,
+		X:  cause.Index,
+		Y:  &ast.BasicLit{Value: "1"},
+	}
+	c.ctx.Warn(cause, "index expr always panics; maybe you wanted %s?", suggest)
+}

--- a/testdata/_integration/check_main_only/linttest.golden
+++ b/testdata/_integration/check_main_only/linttest.golden
@@ -25,6 +25,7 @@ exit status 1
 ./main.go:125:6: indexAlloc: consider replacing strings.Index(string(s), sub) with bytes.Index(s, []byte(sub))
 ./main.go:129:6: methodExprCall: consider to change `point.String` to `p.String`
 ./main.go:134:3: nilValReturn: returned expr is always nil; replace x with nil
+./main.go:233:9: offBy1: index expr always panics; maybe you wanted xs[len(xs)-1]?
 ./main.go:139:1: paramTypeCombine: func(x int, y int) could be replaced with func(x, y int)
 ./main.go:142:2: rangeExprCopy: copy of xs (8000 bytes) can be avoided with &xs
 ./main.go:148:2: rangeValCopy: each iteration copies 8000 bytes (consider pointers or indexing)

--- a/testdata/_integration/check_main_only/main.go
+++ b/testdata/_integration/check_main_only/main.go
@@ -229,5 +229,9 @@ func (p point) String() string {
 	return fmt.Sprintf("(%d, %d)", p.x, p.y)
 }
 
+func offBy1(xs []int) int {
+	return xs[len(xs)]
+}
+
 func main() {
 }

--- a/testdata/offBy1/negative_tests.go
+++ b/testdata/offBy1/negative_tests.go
@@ -1,0 +1,19 @@
+package checker_test
+
+func makeSlice() []int {
+	return []int{}
+}
+
+func goodLenIndex(xs []int, ys []string) {
+	_ = xs[len(xs)-1]
+	_ = ys[len(ys)-1]
+
+	// Conservative with function call.
+	// Might return different lengths for both calls.
+	_ = makeSlice()[len(makeSlice())]
+
+	var m map[int]int
+
+	// Not an error. Doesn't panic.
+	_ = m[len(m)]
+}

--- a/testdata/offBy1/positive_tests.go
+++ b/testdata/offBy1/positive_tests.go
@@ -1,0 +1,8 @@
+package checker_test
+
+func lenIndex(xs []int, ys []string) {
+	/*! index expr always panics; maybe you wanted xs[len(xs)-1]? */
+	_ = xs[len(xs)]
+	/*! index expr always panics; maybe you wanted ys[len(ys)-1]? */
+	_ = ys[len(ys)]
+}


### PR DESCRIPTION
Only detects the trivial s[len(s)] problem.
New patterns can be added later.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>